### PR TITLE
Integrate RSEM quantification into pipeline

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -64,3 +64,4 @@ params:
   cutadapt-pe: ""
   cutadapt-se: ""
   star: ""
+  rsem: ""

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -27,6 +27,7 @@ include: "rules/ref.smk"
 include: "rules/trim.smk"
 include: "rules/qc.smk"
 include: "rules/align.smk"
+include: "rules/rsem.smk"
 include: "rules/diffexp.smk"
 
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -21,6 +21,23 @@ def get_final_output():
     final_output.append("results/counts/all.symbol.tsv")
     final_output.append("results/qc/multiqc_report.html")
 
+    final_output.extend(
+        expand(
+            "results/rsem/{sample}_{unit}.genes.results",
+            zip,
+            sample=units.index.get_level_values("sample_name"),
+            unit=units.index.get_level_values("unit_name"),
+        )
+    )
+    final_output.extend(
+        expand(
+            "results/rsem/{sample}_{unit}.isoforms.results",
+            zip,
+            sample=units.index.get_level_values("sample_name"),
+            unit=units.index.get_level_values("unit_name"),
+        )
+    )
+
     if config["pca"]["activate"]:
         # get all the variables to plot a PCA for
         pca_variables = list(config["diffexp"]["variables_of_interest"])

--- a/workflow/rules/rsem.smk
+++ b/workflow/rules/rsem.smk
@@ -1,0 +1,42 @@
+rule rsem_index:
+    input:
+        fasta="resources/genome.fasta",
+        gtf="resources/genome.gtf",
+    output:
+        transcripts="resources/rsem/rsem.transcripts.fa",
+    params:
+        prefix=lambda wc, output: output.transcripts.replace(".transcripts.fa", ""),
+        extra=config["params"]["rsem"],
+    log:
+        "logs/rsem/prepare_reference.log",
+    threads: 8
+    cache: True
+    container: "docker://daylilyinformatics/rsem:1.3.3.1"
+    shell:
+        """
+        rsem-prepare-reference --gtf {input.gtf} {input.fasta} {params.extra} {params.prefix} &> {log}
+        """
+
+
+rule rsem_quant:
+    input:
+        bam="results/star/{sample}_{unit}/Aligned.sortedByCoord.out.bam",
+        ref="resources/rsem/rsem.transcripts.fa",
+    output:
+        genes="results/rsem/{sample}_{unit}.genes.results",
+        isoforms="results/rsem/{sample}_{unit}.isoforms.results",
+    log:
+        "logs/rsem/{sample}_{unit}.log",
+    benchmark:
+        "logs/rsem/{sample}_{unit}.bench.tsv",
+    threads: 8
+    params:
+        prefix=lambda wc, input: input.ref.replace(".transcripts.fa", ""),
+        extra=config["params"]["rsem"],
+        paired=lambda wc: "--paired-end" if is_paired_end(wc.sample) else "",
+    container: "docker://daylilyinformatics/rsem:1.3.3.1"
+    shell:
+        """
+        rsem-calculate-expression --alignments {params.paired} -p {threads} {params.extra} {input.bam} {params.prefix} results/rsem/{wildcards.sample}_{wildcards.unit} &> {log}
+        """
+


### PR DESCRIPTION
## Summary
- add Snakemake rules to build an RSEM reference and quantify STAR BAMs
- wire up RSEM outputs as workflow targets and configuration

## Testing
- `snakemake --lint`

------
https://chatgpt.com/codex/tasks/task_e_68c0bb1f1300833193366c527c430769