### PR TITLE
Add RSEM bowtie pipeline rule

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -37,6 +37,14 @@ def get_final_output():
             unit=units.index.get_level_values("unit_name"),
         )
     )
+    final_output.extend(
+        expand(
+            "results/rsem/{sample}_{unit}.genome.sorted.wig",
+            zip,
+            sample=units.index.get_level_values("sample_name"),
+            unit=units.index.get_level_values("unit_name"),
+        )
+    )
 
     if config["pca"]["activate"]:
         # get all the variables to plot a PCA for

--- a/workflow/rules/rsem.smk
+++ b/workflow/rules/rsem.smk
@@ -40,3 +40,33 @@ rule rsem_quant:
         rsem-calculate-expression --alignments {params.paired} -p {threads} {params.extra} {input.bam} {params.prefix} results/rsem/{wildcards.sample}_{wildcards.unit} &> {log}
         """
 
+
+rule rsem_bowtie:
+    input:
+        unpack(get_fq),
+        ref="resources/rsem/rsem.transcripts.fa",
+    output:
+        genes="results/rsem/{sample}_{unit}.genes.results",
+        isoforms="results/rsem/{sample}_{unit}.isoforms.results",
+        bam="results/rsem/{sample}_{unit}.genome.sorted.bam",
+        bai="results/rsem/{sample}_{unit}.genome.sorted.bam.bai",
+        wig="results/rsem/{sample}_{unit}.genome.sorted.wig",
+    log:
+        "logs/rsem/{sample}_{unit}.bowtie.log",
+    benchmark:
+        "logs/rsem/{sample}_{unit}.bowtie.bench.tsv",
+    threads: 8
+    params:
+        prefix=lambda wc, input: input.ref.replace(".transcripts.fa", ""),
+        extra=config["params"]["rsem"],
+        paired=lambda wc: "--paired-end" if is_paired_end(wc.sample) else "",
+        fq_inputs=lambda wc, input: " ".join([input.fq1] + ([input.fq2] if is_paired_end(wc.sample) else [])),
+    container: "docker://daylilyinformatics/rsem:1.3.3.1"
+    shell:
+        """
+        (
+        rsem-calculate-expression {params.paired} --sort-bam-by-coordinate --output-genome-bam -p {threads} {params.extra} {params.fq_inputs} {params.prefix} results/rsem/{wildcards.sample}_{wildcards.unit} &&
+        rsem-bam2wig {output.bam} {output.wig} {wildcards.sample}_{wildcards.unit}
+        ) &> {log}
+        """
+


### PR DESCRIPTION
## Summary
- Add `rsem_bowtie` rule to run RSEM with Bowtie, generating genome-sorted BAM and wig for visualization
- Track wig visualization output in final workflow outputs

## Testing
- ⚠️ `python - <<'PY' ... snakemake.main(['--snakefile','workflow/Snakefile','-n','results/rsem/a_1.genome.sorted.wig'])
PY` (missing input fastqs)

------
https://chatgpt.com/codex/tasks/task_e_68c23137e4448331bbc663c9d0aa7410