### PR TITLE
Implement stranded count normalization and DESeq2 workflows

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -44,14 +44,14 @@ diffexp:
   variables_of_interest:
     condition:
       # any fold change will be relative to this factor level
-      base_level: untreated
+      base_level: normal
   batch_effects: ""
   # contrasts for the deseq2 results method to determine fold changes
   contrasts:
-    treated-vs-untreated:
+    tumor-vs-normal:
       # must be one of the variables_of_interest
       variable_of_interest: condition
-      level_of_interest: untreated
+      level_of_interest: tumor
   # The default model includes all interactions among variables_of_interest
   # and batch_effects added on. For the example above this implicitly is:
   # model: ~condition

--- a/config/samples.tsv
+++ b/config/samples.tsv
@@ -1,2 +1,2 @@
-sample_name	condition
-R0b_H37021-20250314-ILMN-rnaseq-tissue-tumor_TTGGACTT-ATCCACTG_0	untreated
+sample_name	condition	patient
+R0b_H37021-20250314-ILMN-rnaseq-tissue-tumor_TTGGACTT-ATCCACTG_0	tumor	patient1

--- a/config/units.tsv
+++ b/config/units.tsv
@@ -1,0 +1,2 @@
+sample_name	unit_name	fq1	fq2	sra	adapters	strandedness
+R0b_H37021-20250314-ILMN-rnaseq-tissue-tumor_TTGGACTT-ATCCACTG_0	unit1	/path/to/sample_R1.fastq.gz	/path/to/sample_R2.fastq.gz			none

--- a/workflow/rules/align.smk
+++ b/workflow/rules/align.smk
@@ -6,6 +6,7 @@ rule align:
     output:
         aln="results/star/{sample}_{unit}/Aligned.sortedByCoord.out.bam",
         reads_per_gene="results/star/{sample}_{unit}/ReadsPerGene.out.tab",
+        transcriptome="results/star/{sample}_{unit}/Aligned.toTranscriptome.out.bam",
     log:
         "logs/star/{sample}_{unit}.log",
     benchmark:
@@ -13,6 +14,6 @@ rule align:
     threads: 127
     params:
         idx=lambda wc, input: input.index,
-        extra=lambda wc, input: f'--outSAMtype BAM SortedByCoordinate --quantMode GeneCounts --sjdbGTFfile {input.gtf} {config["params"]["star"]} ',
+        extra=lambda wc, input: f'--outSAMtype BAM SortedByCoordinate --quantMode GeneCounts TranscriptomeSAM --sjdbGTFfile {input.gtf} {config["params"]["star"]} ',
     wrapper:
         "v3.5.3/bio/star/align"

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -13,12 +13,19 @@ samples = (
 
 
 def get_final_output():
-    final_output = expand(
-        "results/diffexp/{contrast}.diffexp.symbol.tsv",
-        contrast=config["diffexp"]["contrasts"],
-    )
+    final_output = []
+    if len(samples) >= 2:
+        final_output.extend(
+            expand(
+                "results/diffexp/{contrast}.diffexp.symbol.tsv",
+                contrast=config["diffexp"]["contrasts"],
+            )
+        )
     #final_output.append("results/deseq2/normcounts.symbol.tsv")
     final_output.append("results/counts/all.symbol.tsv")
+    final_output.append("results/counts/normalized.deseq.tsv")
+    final_output.append("results/deseq2/normcounts.tsv")
+    final_output.append("results/deseq2/normcounts.symbol.tsv")
     final_output.append("results/qc/multiqc_report.html")
 
     if config["pca"]["activate"]:
@@ -42,6 +49,8 @@ units = (
     .sort_index()
 )
 validate(units, schema="../schemas/units.schema.yaml")
+
+units_list = list(units.itertuples())
 
 
 wildcard_constraints:

--- a/workflow/rules/diffexp.smk
+++ b/workflow/rules/diffexp.smk
@@ -1,16 +1,20 @@
 rule count_matrix:
     input:
-        expand(
+        reads=expand(
             "results/star/{unit.sample_name}_{unit.unit_name}/ReadsPerGene.out.tab",
-            unit=units.itertuples(),
+            unit=units_list,
+        ),
+        infer=expand(
+            "results/qc/rseqc/{unit.sample_name}_{unit.unit_name}.infer_experiment.txt",
+            unit=units_list,
         ),
     output:
         "results/counts/all.tsv",
     log:
         "logs/count-matrix.log",
     params:
-        samples=units["sample_name"].tolist(),
-        strand=get_strandedness(units),
+        samples=[unit.sample_name for unit in units_list],
+        fallback_strand=get_strandedness(units),
     conda:
         "../envs/pandas.yaml"
     script:
@@ -26,31 +30,26 @@ rule gene_2_symbol:
         species=get_bioc_species_name(),
     log:
         "logs/gene2symbol/{prefix}.log",
-    conda:
-        "../envs/biomart.yaml"
-    shell:
-        """
-        touch {output}
-        """
+    container:
+        "docker://bioconductor/bioconductor_docker:RELEASE_3_18"
+    script:
+        "../scripts/gene2symbol.R"
 
 
 rule deseq2_init:
     input:
         counts="results/counts/all.tsv",
     output:
-        "results/deseq2/all.rds",
-        "results/deseq2/normcounts.tsv",
-    conda:
-        "../envs/deseq2.yaml"
+        dds="results/deseq2/all.rds",
+        normcounts="results/deseq2/normcounts.tsv",
+        normalized="results/counts/normalized.deseq.tsv",
+    container:
+        "docker://bioconductor/bioconductor_docker:RELEASE_3_18"
     log:
         "logs/deseq2/init.log",
     threads: get_deseq2_threads()
-    shell:
-        """
-        echo 'A' >> {log};
-        touch {output} >> {log};
-        echo 'B' >> {log}
-        """
+    script:
+        "../scripts/deseq2-init.R"
 
 
 localrules: pca, deseq2
@@ -59,12 +58,12 @@ rule pca:
         "results/deseq2/all.rds",
     output:
         report("results/pca.{variable}.svg", "../report/pca.rst"),
-    conda:
-        "../envs/deseq2.yaml"
+    container:
+        "docker://bioconductor/bioconductor_docker:RELEASE_3_18"
     log:
         "logs/pca.{variable}.log",
-    shell:
-        "touch {output}"
+    script:
+        "../scripts/plot-pca.R"
 
 #rule pca:
 #    input:
@@ -87,11 +86,11 @@ rule deseq2:
         ma_plot=report("results/diffexp/{contrast}.ma-plot.svg", "../report/ma.rst"),
     params:
         contrast=get_contrast,
-    conda:
-        "../envs/deseq2.yaml"
+    container:
+        "docker://bioconductor/bioconductor_docker:RELEASE_3_18"
     log:
         "logs/deseq2/{contrast}.diffexp.log",
     threads: get_deseq2_threads()
-    shell:
-        "touch {output}"
+    script:
+        "../scripts/deseq2.R"
 

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -167,48 +167,102 @@ rule rseqc_readgc:
         """
 
 
+rule rseqc_gene_body_coverage:
+    input:
+        bam="results/star/{sample}_{unit}/Aligned.sortedByCoord.out.bam",
+        bed="results/qc/rseqc/annotation.bed",
+    output:
+        txt="results/qc/rseqc/{sample}_{unit}.genebody.geneBodyCoverage.txt",
+        pdf="results/qc/rseqc/{sample}_{unit}.genebody.geneBodyCoverage.pdf",
+    threads: 32
+    priority: 1
+    log:
+        "logs/rseqc/rseqc_gene_body/{sample}_{unit}.log",
+    params:
+        prefix=lambda w, output: output.txt.replace(".geneBodyCoverage.txt", ""),
+    conda:
+        "../envs/rseqc.yaml"
+    shell:
+        """
+        geneBody_coverage.py -r {input.bed} -i {input.bam} -o {params.prefix} > {log} 2>&1;
+        """
+
+
+rule rseqc_gene_body_coverage_all:
+    input:
+        bams=expand(
+            "results/star/{unit.sample_name}_{unit.unit_name}/Aligned.sortedByCoord.out.bam",
+            unit=units_list,
+        ),
+        bed="results/qc/rseqc/annotation.bed",
+    output:
+        txt="results/qc/rseqc/all.genebody.geneBodyCoverage.txt",
+        pdf="results/qc/rseqc/all.genebody.geneBodyCoverage.pdf",
+    threads: 32
+    log:
+        "logs/rseqc/rseqc_gene_body/all.log",
+    params:
+        prefix="results/qc/rseqc/all.genebody",
+    conda:
+        "../envs/rseqc.yaml"
+    shell:
+        """
+        geneBody_coverage.py -r {input.bed} -i {input.bams} -o {params.prefix} > {log} 2>&1;
+        """
+
+
 rule multiqc:
     input:
         expand(
             "results/star/{unit.sample_name}_{unit.unit_name}/Aligned.sortedByCoord.out.bam",
-            unit=units.itertuples(),
+            unit=units_list,
         ),
         expand(
             "results/qc/rseqc/{unit.sample_name}_{unit.unit_name}.junctionanno.junction.bed",
-            unit=units.itertuples(),
+            unit=units_list,
         ),
         expand(
             "results/qc/rseqc/{unit.sample_name}_{unit.unit_name}.junctionsat.junctionSaturation_plot.pdf",
-            unit=units.itertuples(),
+            unit=units_list,
         ),
         expand(
             "results/qc/rseqc/{unit.sample_name}_{unit.unit_name}.infer_experiment.txt",
-            unit=units.itertuples(),
+            unit=units_list,
         ),
         expand(
             "results/qc/rseqc/{unit.sample_name}_{unit.unit_name}.stats.txt",
-            unit=units.itertuples(),
+            unit=units_list,
         ),
         expand(
             "results/qc/rseqc/{unit.sample_name}_{unit.unit_name}.inner_distance_freq.inner_distance.txt",
-            unit=units.itertuples(),
+            unit=units_list,
         ),
         expand(
             "results/qc/rseqc/{unit.sample_name}_{unit.unit_name}.readdistribution.txt",
-            unit=units.itertuples(),
+            unit=units_list,
         ),
         expand(
             "results/qc/rseqc/{unit.sample_name}_{unit.unit_name}.readdup.DupRate_plot.pdf",
-            unit=units.itertuples(),
+            unit=units_list,
         ),
         expand(
             "results/qc/rseqc/{unit.sample_name}_{unit.unit_name}.readgc.GC_plot.pdf",
-            unit=units.itertuples(),
+            unit=units_list,
         ),
         expand(
             "logs/rseqc/rseqc_junction_annotation/{unit.sample_name}_{unit.unit_name}.log",
-            unit=units.itertuples(),
+            unit=units_list,
         ),
+        expand(
+            "results/qc/rseqc/{unit.sample_name}_{unit.unit_name}.genebody.geneBodyCoverage.txt",
+            unit=units_list,
+        ),
+        expand(
+            "results/qc/rseqc/{unit.sample_name}_{unit.unit_name}.genebody.geneBodyCoverage.pdf",
+            unit=units_list,
+        ),
+        "results/qc/rseqc/all.genebody.geneBodyCoverage.txt",
+        "results/qc/rseqc/all.genebody.geneBodyCoverage.pdf",
     threads: 32
     output:
         "results/qc/multiqc_report.html",

--- a/workflow/schemas/samples.schema.yaml
+++ b/workflow/schemas/samples.schema.yaml
@@ -5,6 +5,16 @@ properties:
   sample_name:
     type: string
     description: sample name/identifier
+  condition:
+    type: string
+    description: biological condition label (tumor or normal)
+    enum:
+      - tumor
+      - normal
+  patient:
+    type: string
+    description: optional patient identifier for paired analyses
 
 required:
   - sample_name
+  - condition

--- a/workflow/scripts/count-matrix.py
+++ b/workflow/scripts/count-matrix.py
@@ -1,40 +1,95 @@
+import json
 import sys
-
-# logging
-sys.stderr = open(snakemake.log[0], "w")
+from pathlib import Path
 
 import pandas as pd
 
 
-def get_column(strandedness):
-    if pd.isnull(strandedness) or strandedness == "none":
-        return 1  # non stranded protocol
-    elif strandedness == "yes":
-        return 2  # 3rd column
-    elif strandedness == "reverse":
-        return 3  # 4th column, usually for Illumina truseq
-    else:
-        raise ValueError(
-            (
-                "'strandedness' column should be empty or have the "
-                "value 'none', 'yes' or 'reverse', instead has the "
-                "value {}"
-            ).format(repr(strandedness))
+sys.stderr = open(snakemake.log[0], "w")
+
+
+STAR_COLUMNS = {"none": 1, "yes": 2, "reverse": 3}
+
+
+def infer_star_column(infer_path: Path, fallback: str, sample: str) -> int:
+    fallback = fallback if isinstance(fallback, str) else "none"
+    column = STAR_COLUMNS.get(fallback, 1)
+
+    if not infer_path.exists():
+        print(
+            f"[count-matrix] sample={sample} infer_experiment missing; fallback to {fallback} (col {column})"
         )
+        return column
 
+    sf = sr = None
+    with infer_path.open() as handle:
+        for line in handle:
+            if line.startswith("1++,1--,2+-,2-+"):
+                try:
+                    sf = float(line.split(":", 1)[1].strip())
+                except ValueError:
+                    pass
+            elif line.startswith("1+-,1-+,2++,2--"):
+                try:
+                    sr = float(line.split(":", 1)[1].strip())
+                except ValueError:
+                    pass
 
-counts = [
-    pd.read_table(
-        f, index_col=0, usecols=[0, get_column(strandedness)], header=None, skiprows=4
+    if sf is not None and sf > 0.6:
+        column = 2  # STAR column 3
+    elif sr is not None and sr > 0.6:
+        column = 3  # STAR column 4
+    else:
+        column = 1  # STAR column 2
+
+    print(
+        json.dumps(
+            {
+                "sample": sample,
+                "infer": str(infer_path),
+                "sf": sf,
+                "sr": sr,
+                "fallback": fallback,
+                "column": column,
+            }
+        )
     )
-    for f, strandedness in zip(snakemake.input, snakemake.params.strand)
-]
+    return column
 
-for t, sample in zip(counts, snakemake.params.samples):
-    t.columns = [sample]
+
+reads_files = list(snakemake.input.get("reads", []))
+infer_files = list(snakemake.input.get("infer", []))
+samples = list(snakemake.params.samples)
+fallbacks = list(snakemake.params.fallback_strand)
+
+if not (len(reads_files) == len(samples) == len(fallbacks)):
+    raise ValueError("Input/parameter lengths are inconsistent for count matrix generation")
+
+if len(infer_files) not in (0, len(reads_files)):
+    raise ValueError("Mismatch between gene count files and infer_experiment outputs")
+
+counts = []
+for read_file, infer_file, sample, fallback in zip(
+    reads_files,
+    infer_files,
+    samples,
+    fallbacks,
+):
+    column = infer_star_column(Path(infer_file), fallback, sample)
+    table = pd.read_table(
+        read_file,
+        index_col=0,
+        usecols=[0, column],
+        header=None,
+        skiprows=4,
+    )
+    table.columns = [sample]
+    counts.append(table)
+
+if not counts:
+    raise ValueError("No STAR gene count files detected")
 
 matrix = pd.concat(counts, axis=1)
 matrix.index.name = "gene"
-# collapse technical replicates
 matrix = matrix.groupby(matrix.columns, axis=1, sort=False).sum()
 matrix.to_csv(snakemake.output[0], sep="\t")

--- a/workflow/scripts/plot-pca.R
+++ b/workflow/scripts/plot-pca.R
@@ -1,14 +1,30 @@
+suppressPackageStartupMessages({
+  library("DESeq2")
+})
+
 log <- file(snakemake@log[[1]], open = "wt")
 sink(log)
 sink(log, type = "message")
 
-library("DESeq2")
-
 # load deseq2 data
 dds <- readRDS(snakemake@input[[1]])
 
-# obtain normalized counts
-counts <- rlog(dds, blind=FALSE)
 svg(snakemake@output[[1]])
+if (ncol(dds) < 2) {
+  plot.new()
+  text(0.5, 0.5, "PCA requires at least two samples")
+  dev.off()
+  sink(type = "message")
+  sink()
+  close(log)
+  quit(save = "no")
+}
+
+# obtain normalized counts
+counts <- rlog(dds, blind = FALSE)
 plotPCA(counts, intgroup = snakemake@wildcards[["variable"]])
 dev.off()
+
+sink(type = "message")
+sink()
+close(log)


### PR DESCRIPTION
## Summary
- infer strandedness from RSeQC outputs when building the STAR gene count matrix and emit DESeq2-normalized tables using the Bioconductor container
- add gene body coverage QC steps and propagate their outputs into MultiQC while updating STAR to retain transcriptome BAMs for downstream quantifiers
- tighten sample metadata expectations for tumor/normal analyses and provide example sample/unit sheets aligned with the new workflow

## Testing
- `snakemake --lint` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb4c74d1648331b1951b667dfe6121