### PR TITLE
Add STAR support for RSEM quantification

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -65,3 +65,6 @@ params:
   cutadapt-se: ""
   star: ""
   rsem: ""
+
+# Select which aligner RSEM should use. Supported values: "star" or "bowtie2".
+rsem_aligner: star

--- a/workflow/rules/rsem.smk
+++ b/workflow/rules/rsem.smk
@@ -1,3 +1,26 @@
+from snakemake.exceptions import WorkflowError
+
+
+def _get_rsem_aligner():
+    aligner = config.get("rsem_aligner", "bowtie2")
+    if isinstance(aligner, str):
+        aligner = aligner.lower()
+    else:
+        raise WorkflowError(
+            f"Expected 'rsem_aligner' to be a string but received {type(aligner)}."
+        )
+    if aligner not in {"star", "bowtie2"}:
+        raise WorkflowError(
+            "Unsupported RSEM aligner '{aligner}'. Choose 'star' or 'bowtie2'.".format(
+                aligner=aligner
+            )
+        )
+    return aligner
+
+
+RSEM_ALIGNER = _get_rsem_aligner()
+
+
 rule rsem_index_star:
     input:
         fasta="resources/genome.fasta",
@@ -55,59 +78,101 @@ rule rsem_index_bowtie2:
         rsem-prepare-reference -p {threads} --bowtie2 --gtf {input.gtf} {input.fasta} {params.extra} {params.prefix} &> {log}
         """
 
-rule rsem_bowtie2_quant:
-    input:
-        bam="results/rsem/{sample}_{unit}.genome.sorted.bam",
-        bai="results/rsem/{sample}_{unit}.genome.sorted.bam.bai",
-        ref="resources/bowtie2_rsem.transcripts.fa",
-    output:
-        genes="results/rsem/x{sample}_{unit}.genes.results",
-        isoforms="results/rsem/x{sample}_{unit}.isoforms.results",
-    log:
-        "logs/rsem/{sample}_{unit}.log",
-    benchmark:
-        "logs/rsem/{sample}_{unit}.bench.tsv",
-    threads: 190
-    params:
-        prefix=lambda wc, input: input.ref.replace(".transcripts.fa", ""),
-        extra=config["params"]["rsem"],
-        paired=lambda wc: "--paired-end" if is_paired_end(wc.sample) else "",
-    container: "docker://daylilyinformatics/rsem:1.3.3.4"
-    shell:
-        """
-        rsem-calculate-expression --bowtie2 --alignments {params.paired} -p {threads} {params.extra} {input.bam} {params.prefix} results/rsem/{wildcards.sample}_{wildcards.unit} &> {log}
-        """
+if RSEM_ALIGNER == "star":
+
+    rule rsem_star:
+        input:
+            unpack(get_fq),
+            ref="resources/star_rsem.transcripts.fa",
+        output:
+            genes="results/rsem/{sample}_{unit}.genes.results",
+            isoforms="results/rsem/{sample}_{unit}.isoforms.results",
+            bam="results/rsem/{sample}_{unit}.genome.sorted.bam",
+            bai="results/rsem/{sample}_{unit}.genome.sorted.bam.bai",
+            wig="results/rsem/{sample}_{unit}.genome.sorted.wig",
+        log:
+            "logs/rsem/{sample}_{unit}.star.log",
+        benchmark:
+            "logs/rsem/{sample}_{unit}.star.bench.tsv",
+        threads: 190
+        params:
+            prefix=lambda wc, input: input.ref.replace(".transcripts.fa", ""),
+            extra=config["params"]["rsem"],
+            paired=lambda wc: "--paired-end" if is_paired_end(wc.sample) else "",
+            fq_inputs=lambda wc, input: " ".join([input.fq1] + ([input.fq2] if is_paired_end(wc.sample) else [])),
+            star_gzipped=lambda wc, input: (
+                "--star-gzipped-read-file"
+                if any(
+                    str(f).endswith(".gz")
+                    for f in [input.fq1]
+                    + ([input.fq2] if is_paired_end(wc.sample) else [])
+                )
+                else ""
+            ),
+        container: "docker://daylilyinformatics/rsem:1.3.3.4"
+        shell:
+            """
+            (
+            rsem-calculate-expression --star {params.star_gzipped} {params.paired} --sort-bam-by-coordinate --output-genome-bam -p {threads} {params.extra} {params.fq_inputs} {params.prefix} results/rsem/{wildcards.sample}_{wildcards.unit} &&
+            rsem-bam2wig {output.bam} {output.wig} {wildcards.sample}_{wildcards.unit}
+            ) &> {log}
+            """
+
+else:
+
+    rule rsem_bowtie2_quant:
+        input:
+            bam="results/rsem/{sample}_{unit}.genome.sorted.bam",
+            bai="results/rsem/{sample}_{unit}.genome.sorted.bam.bai",
+            ref="resources/bowtie2_rsem.transcripts.fa",
+        output:
+            genes="results/rsem/x{sample}_{unit}.genes.results",
+            isoforms="results/rsem/x{sample}_{unit}.isoforms.results",
+        log:
+            "logs/rsem/{sample}_{unit}.log",
+        benchmark:
+            "logs/rsem/{sample}_{unit}.bench.tsv",
+        threads: 190
+        params:
+            prefix=lambda wc, input: input.ref.replace(".transcripts.fa", ""),
+            extra=config["params"]["rsem"],
+            paired=lambda wc: "--paired-end" if is_paired_end(wc.sample) else "",
+        container: "docker://daylilyinformatics/rsem:1.3.3.4"
+        shell:
+            """
+            rsem-calculate-expression --bowtie2 --alignments {params.paired} -p {threads} {params.extra} {input.bam} {params.prefix} results/rsem/{wildcards.sample}_{wildcards.unit} &> {log}
+            """
 
 
-rule rsem_bowtie2:
-    input:
-        unpack(get_fq),
-        ref="resources/bowtie2_rsem.transcripts.fa",
-    output:
-        genes="results/rsem/{sample}_{unit}.genes.results",
-        isoforms="results/rsem/{sample}_{unit}.isoforms.results",
-        bam="results/rsem/{sample}_{unit}.genome.sorted.bam",
-        bai="results/rsem/{sample}_{unit}.genome.sorted.bam.bai",
-        wig="results/rsem/{sample}_{unit}.genome.sorted.wig",
-    log:
-        "logs/rsem/{sample}_{unit}.bowtie.log",
-    benchmark:
-        "logs/rsem/{sample}_{unit}.bowtie.bench.tsv",
-    threads: 190
-    params:
-        prefix=lambda wc, input: input.ref.replace(".transcripts.fa", ""),
-        extra=config["params"]["rsem"],
-        paired=lambda wc: "--paired-end" if is_paired_end(wc.sample) else "",
-        fq_inputs=lambda wc, input: " ".join([input.fq1] + ([input.fq2] if is_paired_end(wc.sample) else [])),
-    container: "docker://daylilyinformatics/rsem:1.3.3.4"
-    shell:
-        """
-        (
-        rsem-calculate-expression --bowtie2 {params.paired} --sort-bam-by-coordinate --output-genome-bam -p {threads} {params.extra} {params.fq_inputs} {params.prefix} results/rsem/{wildcards.sample}_{wildcards.unit} &&
-        rsem-bam2wig {output.bam} {output.wig} {wildcards.sample}_{wildcards.unit}
-        ) &> {log}
-        """
+    rule rsem_bowtie2:
+        input:
+            unpack(get_fq),
+            ref="resources/bowtie2_rsem.transcripts.fa",
+        output:
+            genes="results/rsem/{sample}_{unit}.genes.results",
+            isoforms="results/rsem/{sample}_{unit}.isoforms.results",
+            bam="results/rsem/{sample}_{unit}.genome.sorted.bam",
+            bai="results/rsem/{sample}_{unit}.genome.sorted.bam.bai",
+            wig="results/rsem/{sample}_{unit}.genome.sorted.wig",
+        log:
+            "logs/rsem/{sample}_{unit}.bowtie.log",
+        benchmark:
+            "logs/rsem/{sample}_{unit}.bowtie.bench.tsv",
+        threads: 190
+        params:
+            prefix=lambda wc, input: input.ref.replace(".transcripts.fa", ""),
+            extra=config["params"]["rsem"],
+            paired=lambda wc: "--paired-end" if is_paired_end(wc.sample) else "",
+            fq_inputs=lambda wc, input: " ".join([input.fq1] + ([input.fq2] if is_paired_end(wc.sample) else [])),
+        container: "docker://daylilyinformatics/rsem:1.3.3.4"
+        shell:
+            """
+            (
+            rsem-calculate-expression --bowtie2 {params.paired} --sort-bam-by-coordinate --output-genome-bam -p {threads} {params.extra} {params.fq_inputs} {params.prefix} results/rsem/{wildcards.sample}_{wildcards.unit} &&
+            rsem-bam2wig {output.bam} {output.wig} {wildcards.sample}_{wildcards.unit}
+            ) &> {log}
+            """
 
-ruleorder:
-    rsem_bowtie2 > rsem_bowtie2_quant
+    ruleorder:
+        rsem_bowtie2 > rsem_bowtie2_quant
 

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -63,12 +63,18 @@ properties:
         type: string
       cutadapt-se:
         type: string
-      star: 
+      star:
         type: string
     required:
       - cutadapt-pe
       - cutadapt-se
       - star
+
+  rsem_aligner:
+    type: string
+    enum:
+      - star
+      - bowtie2
 
 required:
   - samples


### PR DESCRIPTION
## Summary
- allow selecting the RSEM aligner via configuration
- add a STAR-based rsem-calculate-expression workflow including wig generation
- extend the config schema to validate the new aligner option

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cbce8b60b0833180ee73e52b02a7c8