### PR TITLE
Add dedicated terminal targets and workflow help

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -1,3 +1,6 @@
+import textwrap
+
+from snakemake.exceptions import WorkflowError
 from snakemake.utils import min_version
 
 ##### set minimum snakemake version #####
@@ -33,6 +36,69 @@ include: "rules/diffexp.smk"
 
 ##### target rules #####
 
-rule all:
+
+HELP_TEXT = textwrap.dedent(
+    """
+    RNA-seq workflow targets
+    ========================
+
+    This workflow does not run any analysis by default. Choose one of the
+    terminal targets below to execute a portion of the pipeline:
+
+      * snakemake produce_all           # run the full RNA-seq workflow
+      * snakemake produce_rsem_star     # generate RSEM outputs using STAR
+      * snakemake produce_rsem_bowtie2  # generate RSEM outputs using Bowtie2
+
+    Configure the workflow in config/config.yaml. For example, adjust the
+    "rsem_aligner" setting to switch between STAR and Bowtie2 when invoking
+    the dedicated RSEM targets.
+    """
+)
+
+
+rule produce_all:
     input:
         get_final_output(),
+
+
+if RSEM_ALIGNER == "star":
+
+    rule produce_rsem_star:
+        input:
+            get_rsem_outputs(),
+
+
+else:
+
+    rule produce_rsem_star:
+        run:
+            raise WorkflowError(
+                "The RSEM aligner is configured as '{aligner}'. Set 'rsem_aligner' to "
+                "'star' in config/config.yaml or via --config to build this target."
+                .format(aligner=RSEM_ALIGNER)
+            )
+
+
+if RSEM_ALIGNER == "bowtie2":
+
+    rule produce_rsem_bowtie2:
+        input:
+            get_rsem_outputs(),
+
+
+else:
+
+    rule produce_rsem_bowtie2:
+        run:
+            raise WorkflowError(
+                "The RSEM aligner is configured as '{aligner}'. Set 'rsem_aligner' to "
+                "'bowtie2' in config/config.yaml or via --config to build this target."
+                .format(aligner=RSEM_ALIGNER)
+            )
+
+
+rule all:
+    message:
+        HELP_TEXT
+    run:
+        print(HELP_TEXT)

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -12,6 +12,34 @@ samples = (
 )
 
 
+def get_rsem_outputs():
+    outputs = list(
+        expand(
+            "results/rsem/{sample}_{unit}.genes.results",
+            zip,
+            sample=units.index.get_level_values("sample_name"),
+            unit=units.index.get_level_values("unit_name"),
+        )
+    )
+    outputs.extend(
+        expand(
+            "results/rsem/{sample}_{unit}.isoforms.results",
+            zip,
+            sample=units.index.get_level_values("sample_name"),
+            unit=units.index.get_level_values("unit_name"),
+        )
+    )
+    outputs.extend(
+        expand(
+            "results/rsem/{sample}_{unit}.genome.sorted.wig",
+            zip,
+            sample=units.index.get_level_values("sample_name"),
+            unit=units.index.get_level_values("unit_name"),
+        )
+    )
+    return outputs
+
+
 def get_final_output():
     #final_output = expand(
     #    "results/diffexp/{contrast}.diffexp.symbol.tsv",
@@ -21,38 +49,7 @@ def get_final_output():
     #final_output.append("results/counts/all.symbol.tsv")
     #final_output.append("results/qc/multiqc_report.html")
 
-    final_output = expand(
-        expand(
-            "results/rsem/{sample}_{unit}.genes.results",
-            zip,
-            sample=units.index.get_level_values("sample_name"),
-            unit=units.index.get_level_values("unit_name"),
-        )
-    )
-    final_output.extend(
-        expand(
-            "results/rsem/{sample}_{unit}.isoforms.results",
-            zip,
-            sample=units.index.get_level_values("sample_name"),
-            unit=units.index.get_level_values("unit_name"),
-        )
-    )
-    #final_output.extend(
-    #    expand(
-    #        "results/rsem/x{sample}_{unit}.isoforms.results",
-    #        zip,
-    #        sample=units.index.get_level_values("sample_name"),
-    #unit=units.index.get_level_values("unit_name"),
-    #)
-    #)
-    final_output.extend(
-        expand(
-            "results/rsem/{sample}_{unit}.genome.sorted.wig",
-            zip,
-            sample=units.index.get_level_values("sample_name"),
-            unit=units.index.get_level_values("unit_name"),
-        )
-    )
+    final_output = get_rsem_outputs()
 
     if config["pca"]["activate"]:
         # get all the variables to plot a PCA for


### PR DESCRIPTION
## Summary
- rename the default terminal rule to produce_all and add help text for the workflow entrypoint
- add produce_rsem_star and produce_rsem_bowtie2 terminal targets
- centralize RSEM output expansion for reuse by the new targets

## Testing
- `snakemake -n` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc88db724c83318674e3da7c1b7b76