### PR TITLE
Provide shell-based help for default Snakemake target

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -100,5 +100,5 @@ else:
 rule all:
     message:
         HELP_TEXT
-    run:
-        print(HELP_TEXT)
+    shell:
+        lambda wildcards: "cat <<'EOF'\n" + HELP_TEXT + "\nEOF"


### PR DESCRIPTION
## Summary
- replace the default `all` rule's Python `run` block with a `shell` directive that prints the workflow help guidance when Snakemake runs without explicit targets

## Testing
- not run (Snakemake is not installed in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cc953bf9c8833196f0739b4ca48572