### PR TITLE
Use snakemake-aws fork and add benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,17 @@ git clone git@github.com:Daylily-Informatics/rna-seq-star-deseq2.git
 cd rna-seq-star-deseq2
 ```
 
-## Build The Snakemake (v8.*) Conda Env
+## Build The Snakemake (v9.11.4.1) Conda Env
+Install the Daylily-Informatics fork of Snakemake that bundles AWS ParallelCluster integration alongside the executor plugin dependencies.
 ```bash
-conda create -n snakemake -c conda-forge  snakemake==9.5.1 snakedeploy tabulate yaml
+conda create -n snakemake -c conda-forge python=3.11 pip snakedeploy tabulate yaml
 conda activate snakemake
+pip install "git+https://github.com/Daylily-Informatics/snakemake-aws@v9.11.4.1"
 pip install snakemake-executor-plugin-pcluster-slurm==0.0.31
 
 conda activate snakemake
 snakemake --version
-# 9.5.1 
+# 9.11.4.1
 ```
 
 ### Run Test Data Workflow

--- a/workflow/rules/diffexp.smk
+++ b/workflow/rules/diffexp.smk
@@ -8,6 +8,8 @@ rule count_matrix:
         "results/counts/all.tsv",
     log:
         "logs/count-matrix.log",
+    benchmark:
+        "logs/benchmarks/count_matrix.bench.tsv",
     params:
         samples=units["sample_name"].tolist(),
         strand=get_strandedness(units),
@@ -26,6 +28,8 @@ rule gene_2_symbol:
         species=get_bioc_species_name(),
     log:
         "logs/gene2symbol/{prefix}.log",
+    benchmark:
+        "logs/benchmarks/gene_2_symbol/{prefix}.bench.tsv",
     conda:
         "../envs/biomart.yaml"
     shell:
@@ -44,6 +48,8 @@ rule deseq2_init:
         "../envs/deseq2.yaml"
     log:
         "logs/deseq2/init.log",
+    benchmark:
+        "logs/benchmarks/deseq2_init.bench.tsv",
     threads: get_deseq2_threads()
     shell:
         """
@@ -63,6 +69,8 @@ rule pca:
         "../envs/deseq2.yaml"
     log:
         "logs/pca.{variable}.log",
+    benchmark:
+        "logs/benchmarks/pca/{variable}.bench.tsv",
     shell:
         "touch {output}"
 
@@ -91,6 +99,8 @@ rule deseq2:
         "../envs/deseq2.yaml"
     log:
         "logs/deseq2/{contrast}.diffexp.log",
+    benchmark:
+        "logs/benchmarks/deseq2/{contrast}.bench.tsv",
     threads: get_deseq2_threads()
     shell:
         "touch {output}"

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -111,6 +111,8 @@ rule fastqc:
     threads: 4
     log:
         "logs/fastqc/{sample}_{unit}_{read}.log",
+    benchmark:
+        "logs/benchmarks/fastqc/{sample}_{unit}_{read}.bench.tsv",
     params:
         extra="",
     wrapper:
@@ -126,6 +128,8 @@ rule rseqc_gtf2bed:
     threads: 32
     log:
         "logs/rseqc_gtf2bed.log",
+    benchmark:
+        "logs/benchmarks/rseqc_gtf2bed.bench.tsv",
     conda:
         "../envs/gffutils.yaml"
     script:
@@ -141,6 +145,8 @@ rule rseqc_junction_annotation:
     priority: 1
     log:
         "logs/rseqc/rseqc_junction_annotation/{sample}_{unit}.log",
+    benchmark:
+        "logs/benchmarks/rseqc_junction_annotation/{sample}_{unit}.bench.tsv",
     params:
         extra=r"-q 255",  # STAR uses 255 as a score for unique mappers
         prefix=lambda w, output: output[0].replace(".junction.bed", ""),
@@ -163,6 +169,8 @@ rule rseqc_junction_saturation:
     threads: 32
     log:
         "logs/rseqc/rseqc_junction_saturation/{sample}_{unit}.log",
+    benchmark:
+        "logs/benchmarks/rseqc_junction_saturation/{sample}_{unit}.bench.tsv",
     params:
         extra=r"-q 255",
         prefix=lambda w, output: output[0].replace(".junctionSaturation_plot.pdf", ""),
@@ -181,6 +189,8 @@ rule rseqc_stat:
     priority: 1
     log:
         "logs/rseqc/rseqc_stat/{sample}_{unit}.log",
+    benchmark:
+        "logs/benchmarks/rseqc_stat/{sample}_{unit}.bench.tsv",
     threads: 32
     conda:
         "../envs/rseqc.yaml"
@@ -199,6 +209,8 @@ rule rseqc_infer:
     priority: 1
     log:
         "logs/rseqc/rseqc_infer/{sample}_{unit}.log",
+    benchmark:
+        "logs/benchmarks/rseqc_infer/{sample}_{unit}.bench.tsv",
     threads: 32
     conda:
         "../envs/rseqc.yaml"
@@ -217,6 +229,8 @@ rule rseqc_innerdis:
     priority: 1
     log:
         "logs/rseqc/rseqc_innerdis/{sample}_{unit}.log",
+    benchmark:
+        "logs/benchmarks/rseqc_innerdis/{sample}_{unit}.bench.tsv",
     params:
         prefix=lambda w, output: output[0].replace(".inner_distance.txt", ""),
     threads: 32
@@ -238,6 +252,8 @@ rule rseqc_readdis:
     priority: 1
     log:
         "logs/rseqc/rseqc_readdis/{sample}_{unit}.log",
+    benchmark:
+        "logs/benchmarks/rseqc_readdis/{sample}_{unit}.bench.tsv",
     conda:
         "../envs/rseqc.yaml"
     shell:
@@ -255,6 +271,8 @@ rule rseqc_readdup:
     priority: 1
     log:
         "logs/rseqc/rseqc_readdup/{sample}_{unit}.log",
+    benchmark:
+        "logs/benchmarks/rseqc_readdup/{sample}_{unit}.bench.tsv",
     params:
         prefix=lambda w, output: output[0].replace(".DupRate_plot.pdf", ""),
     conda:
@@ -273,6 +291,8 @@ rule rseqc_readgc:
     priority: 1
     log:
         "logs/rseqc/rseqc_readgc/{sample}_{unit}.log",
+    benchmark:
+        "logs/benchmarks/rseqc_readgc/{sample}_{unit}.bench.tsv",
     params:
         prefix=lambda w, output: output[0].replace(".GC_plot.pdf", ""),
     conda:
@@ -290,6 +310,8 @@ rule multiqc:
         "results/qc/multiqc_report.html",
     log:
         "logs/multiqc.log",
+    benchmark:
+        "logs/benchmarks/multiqc.bench.tsv",
     container:
         "docker://daylilyinformatics/daylily_multiqc:0.2"
     shell:

--- a/workflow/rules/ref.smk
+++ b/workflow/rules/ref.smk
@@ -3,6 +3,8 @@ rule get_genome:
         "resources/genome.fasta",
     log:
         "logs/get-genome.log",
+    benchmark:
+        "logs/benchmarks/get_genome.bench.tsv",
     params:
         species=config["ref"]["species"],
         datatype="dna",
@@ -27,6 +29,8 @@ rule get_annotation:
     threads: 127
     log:
         "logs/get_annotation.log",
+    benchmark:
+        "logs/benchmarks/get_annotation.bench.tsv",
     wrapper:
         "v3.5.3/bio/reference/ensembl-annotation"
 
@@ -38,6 +42,8 @@ rule genome_faidx:
         "resources/genome.fasta.fai",
     log:
         "logs/genome-faidx.log",
+    benchmark:
+        "logs/benchmarks/genome_faidx.bench.tsv",
     cache: True
     threads: 32
     wrapper:
@@ -51,6 +57,8 @@ rule bwa_index:
         multiext("resources/genome.fasta", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     log:
         "logs/bwa_index.log",
+    benchmark:
+        "logs/benchmarks/bwa_index.bench.tsv",
     resources:
         mem_mb=369000,
     cache: True
@@ -69,6 +77,8 @@ rule star_index:
         extra=lambda wc, input: f"--sjdbGTFfile {input.annotation} --sjdbOverhang 100",
     log:
         "logs/star_index_genome.log",
+    benchmark:
+        "logs/benchmarks/star_index.bench.tsv",
     cache: True
     threads: 127
     wrapper:

--- a/workflow/rules/trim.smk
+++ b/workflow/rules/trim.smk
@@ -5,6 +5,8 @@ rule get_sra:
     threads: 31
     log:
         "logs/get-sra/{accession}.log",
+    benchmark:
+        "logs/benchmarks/get_sra/{accession}.bench.tsv",
     wrapper:
         "v3.5.3/bio/sra-tools/fasterq-dump"
 
@@ -16,6 +18,8 @@ rule cutadapt_pipe:
         pipe("pipe/cutadapt/{sample}/{unit}.{fq}.{ext}"),
     log:
         "logs/pipe-fastqs/catadapt/{sample}_{unit}.{fq}.{ext}.log",
+    benchmark:
+        "logs/benchmarks/cutadapt_pipe/{sample}_{unit}.{fq}.{ext}.bench.tsv",
     wildcard_constraints:
         ext=r"fastq|fastq\.gz",
     threads: 1  ## this does something special when running using pipe() output directives
@@ -32,6 +36,8 @@ rule cutadapt_pe:
         qc="results/trimmed/{sample}_{unit}.paired.qc.txt",
     log:
         "logs/cutadapt/{sample}_{unit}.log",
+    benchmark:
+        "logs/benchmarks/cutadapt_pe/{sample}_{unit}.bench.tsv",
     params:
         extra=config["params"]["cutadapt-pe"],
         adapters=lambda w: str(units.loc[w.sample].loc[w.unit, "adapters"]),
@@ -48,6 +54,8 @@ rule cutadapt_se:
         qc="results/trimmed/{sample}_{unit}_single.qc.txt",
     log:
         "logs/cutadapt/{sample}_{unit}.log",
+    benchmark:
+        "logs/benchmarks/cutadapt_se/{sample}_{unit}.bench.tsv",
     params:
         extra=config["params"]["cutadapt-se"],
         adapters=lambda w: str(units.loc[w.sample].loc[w.unit, "adapters"]),


### PR DESCRIPTION
## Summary
- document installation of the Daylily-Informatics snakemake-aws v9.11.4.1 fork via conda + pip
- add benchmark directives to every workflow rule so runtime metrics are captured

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d06c6f20e483319afcd89425895c37