### PR TITLE
Add benchmark directives to non-cached rules

### DIFF
--- a/workflow/rules/diffexp.smk
+++ b/workflow/rules/diffexp.smk
@@ -86,6 +86,8 @@ rule count_matrix:
         "results/counts/all.tsv"
     log:
         "logs/count-matrix.log"
+    benchmark:
+        "logs/count-matrix.bench.tsv"
     params:
         samples = ",".join(units["sample_name"].tolist()),
         strands = lambda wildcards, input: ",".join(
@@ -115,6 +117,8 @@ rule gene_2_symbol:
         species=get_bioc_species_name(),
     log:
         "logs/gene2symbol/{prefix}.log",
+    benchmark:
+        "logs/gene2symbol/{prefix}.bench.tsv",
     conda:
         "../envs/biomart.yaml"
     shell:
@@ -146,6 +150,8 @@ rule deseq2_init:
         "../envs/deseq2.yaml"
     log:
         "logs/deseq2/init.log",
+    benchmark:
+        "logs/deseq2/init.bench.tsv",
     threads: get_deseq2_threads()
     shell:
         """
@@ -165,6 +171,8 @@ rule pca:
         "../envs/deseq2.yaml"
     log:
         "logs/pca.{variable}.log",
+    benchmark:
+        "logs/pca.{variable}.bench.tsv",
     shell:
         "touch {output}"
 
@@ -181,6 +189,8 @@ rule deseq2:
         "../envs/deseq2.yaml"
     log:
         "logs/deseq2/{contrast}.diffexp.log",
+    benchmark:
+        "logs/deseq2/{contrast}.diffexp.bench.tsv",
     threads: get_deseq2_threads()
     shell:
         "touch {output}"

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -89,6 +89,8 @@ rule fastqc:
     threads: 4
     log:
         "logs/fastqc/{sample}_{unit}_{read}.log",
+    benchmark:
+        "logs/fastqc/{sample}_{unit}_{read}.bench.tsv",
     params:
         extra="",
     wrapper:
@@ -104,6 +106,8 @@ rule rseqc_gtf2bed:
     threads: 32
     log:
         "logs/rseqc_gtf2bed.log",
+    benchmark:
+        "logs/rseqc_gtf2bed.bench.tsv",
     conda:
         "../envs/gffutils.yaml"
     shell:
@@ -126,6 +130,8 @@ rule rseqc_junction_annotation:
     priority: 1
     log:
         "logs/rseqc/rseqc_junction_annotation/{sample}_{unit}.log",
+    benchmark:
+        "logs/rseqc/rseqc_junction_annotation/{sample}_{unit}.bench.tsv",
     params:
         extra=r"-q 255",  # STAR uses 255 as a score for unique mappers
         prefix=lambda w, output: output[0].replace(".junction.bed", ""),
@@ -148,6 +154,8 @@ rule rseqc_junction_saturation:
     threads: 32
     log:
         "logs/rseqc/rseqc_junction_saturation/{sample}_{unit}.log",
+    benchmark:
+        "logs/rseqc/rseqc_junction_saturation/{sample}_{unit}.bench.tsv",
     params:
         extra=r"-q 255",
         prefix=lambda w, output: output[0].replace(".junctionSaturation_plot.pdf", ""),
@@ -166,6 +174,8 @@ rule rseqc_stat:
     priority: 1
     log:
         "logs/rseqc/rseqc_stat/{sample}_{unit}.log",
+    benchmark:
+        "logs/rseqc/rseqc_stat/{sample}_{unit}.bench.tsv",
     threads: 32
     conda:
         "../envs/rseqc.yaml"
@@ -184,6 +194,8 @@ rule rseqc_infer:
     priority: 1
     log:
         "logs/rseqc/rseqc_infer/{sample}_{unit}.log",
+    benchmark:
+        "logs/rseqc/rseqc_infer/{sample}_{unit}.bench.tsv",
     threads: 32
     conda:
         "../envs/rseqc.yaml"
@@ -202,6 +214,8 @@ rule rseqc_innerdis:
     priority: 1
     log:
         "logs/rseqc/rseqc_innerdis/{sample}_{unit}.log",
+    benchmark:
+        "logs/rseqc/rseqc_innerdis/{sample}_{unit}.bench.tsv",
     params:
         prefix=lambda w, output: output[0].replace(".inner_distance.txt", ""),
     threads: 32
@@ -223,6 +237,8 @@ rule rseqc_readdis:
     priority: 1
     log:
         "logs/rseqc/rseqc_readdis/{sample}_{unit}.log",
+    benchmark:
+        "logs/rseqc/rseqc_readdis/{sample}_{unit}.bench.tsv",
     conda:
         "../envs/rseqc.yaml"
     shell:
@@ -240,6 +256,8 @@ rule rseqc_readdup:
     priority: 1
     log:
         "logs/rseqc/rseqc_readdup/{sample}_{unit}.log",
+    benchmark:
+        "logs/rseqc/rseqc_readdup/{sample}_{unit}.bench.tsv",
     params:
         prefix=lambda w, output: output[0].replace(".DupRate_plot.pdf", ""),
     conda:
@@ -258,6 +276,8 @@ rule rseqc_readgc:
     priority: 1
     log:
         "logs/rseqc/rseqc_readgc/{sample}_{unit}.log",
+    benchmark:
+        "logs/rseqc/rseqc_readgc/{sample}_{unit}.bench.tsv",
     params:
         prefix=lambda w, output: output[0].replace(".GC_plot.pdf", ""),
     conda:
@@ -276,5 +296,7 @@ rule multiqc:
         "results/qc/multiqc_report.html",
     log:
         "logs/multiqc.log",
+    benchmark:
+        "logs/multiqc.bench.tsv",
     wrapper:
         "v3.5.3/bio/multiqc"

--- a/workflow/rules/trim.smk
+++ b/workflow/rules/trim.smk
@@ -5,6 +5,8 @@ rule get_sra:
     threads: 31
     log:
         "logs/get-sra/{accession}.log",
+    benchmark:
+        "logs/get-sra/{accession}.bench.tsv",
     wrapper:
         "v3.5.3/bio/sra-tools/fasterq-dump"
 
@@ -16,6 +18,8 @@ rule cutadapt_pipe:
         pipe("pipe/cutadapt/{sample}/{unit}.{fq}.{ext}"),
     log:
         "logs/pipe-fastqs/catadapt/{sample}_{unit}.{fq}.{ext}.log",
+    benchmark:
+        "logs/pipe-fastqs/catadapt/{sample}_{unit}.{fq}.{ext}.bench.tsv",
     wildcard_constraints:
         ext=r"fastq|fastq\.gz",
     threads: 1  ## this does something special when running using pipe() output directives
@@ -32,6 +36,8 @@ rule cutadapt_pe:
         qc="results/trimmed/{sample}_{unit}.paired.qc.txt",
     log:
         "logs/cutadapt/{sample}_{unit}.log",
+    benchmark:
+        "logs/cutadapt/{sample}_{unit}.pe.bench.tsv",
     params:
         extra=config["params"]["cutadapt-pe"],
         adapters=lambda w: str(units.loc[w.sample].loc[w.unit, "adapters"]),
@@ -48,6 +54,8 @@ rule cutadapt_se:
         qc="results/trimmed/{sample}_{unit}_single.qc.txt",
     log:
         "logs/cutadapt/{sample}_{unit}.log",
+    benchmark:
+        "logs/cutadapt/{sample}_{unit}.se.bench.tsv",
     params:
         extra=config["params"]["cutadapt-se"],
         adapters=lambda w: str(units.loc[w.sample].loc[w.unit, "adapters"]),


### PR DESCRIPTION
## Summary
- add benchmark output files to trimming, QC, and differential expression rules to record run-time metrics

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5191357748331a768a975be004246