### PR TITLE
Fix cutadapt outputs for Snakemake compatibility

### DIFF
--- a/workflow/rules/trim.smk
+++ b/workflow/rules/trim.smk
@@ -31,9 +31,9 @@ rule cutadapt_pe:
     input:
         get_cutadapt_input,
     output:
-        fastq1=lambda wc: trimmed_fastq_path(wc.sample, wc.unit, "fq1"),
-        fastq2=lambda wc: trimmed_fastq_path(wc.sample, wc.unit, "fq2"),
-        qc=lambda wc: trimmed_qc_path(wc.sample, wc.unit, "paired.qc.txt"),
+        fastq1=trimmed_fastq_path("{sample}", "{unit}", "fq1"),
+        fastq2=trimmed_fastq_path("{sample}", "{unit}", "fq2"),
+        qc=trimmed_qc_path("{sample}", "{unit}", "paired.qc.txt"),
     log:
         "logs/cutadapt/{sample}_{unit}.log",
     benchmark:
@@ -50,8 +50,8 @@ rule cutadapt_se:
     input:
         get_cutadapt_input,
     output:
-        fastq=lambda wc: trimmed_fastq_path(wc.sample, wc.unit, "single"),
-        qc=lambda wc: trimmed_qc_path(wc.sample, wc.unit, "single.qc.txt"),
+        fastq=trimmed_fastq_path("{sample}", "{unit}", "single"),
+        qc=trimmed_qc_path("{sample}", "{unit}", "single.qc.txt"),
     log:
         "logs/cutadapt/{sample}_{unit}.log",
     benchmark:


### PR DESCRIPTION
## Summary
- update the cutadapt paired-end and single-end rules to use literal wildcard-based paths for outputs
- avoid using lambda output functions that are rejected by newer Snakemake versions

## Testing
- snakemake --use-conda --use-singularity \
  --singularity-prefix /fsx/resources/environments/containers/ubuntu/ \
  --singularity-args "-B /tmp:/tmp -B /fsx:/fsx -B /home/$USER:/home/$USER -B $PWD/:$PWD" \
  --conda-prefix /fsx/resources/environments/containers/ubuntu/ \
  --executor pcluster-slurm \
  --default-resources slurm_partition=i192,i128 runtime=86400 mem_mb=36900 tmpdir=/fsx/scratch \
  --cache -p \
  -k \
  --restart-times 2 \
  --max-threads 20000 \
  --cores 20000 -j 14   --include-aws-benchmark-metrics -n *(fails: snakemake not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6562622248331a1971b263e8ba310