### PR TITLE
Fix Snakemake input function usage for compatibility

### DIFF
--- a/workflow/rules/align.smk
+++ b/workflow/rules/align.smk
@@ -1,8 +1,15 @@
+def get_align_inputs(wildcards):
+    files = dict(get_fq(wildcards))
+    files.update({
+        "index": "resources/star_genome",
+        "gtf": "resources/genome.gtf",
+    })
+    return files
+
+
 rule align:
     input:
-        unpack(get_fq),
-        index="resources/star_genome",
-        gtf="resources/genome.gtf",
+        lambda wildcards: get_align_inputs(wildcards),
     output:
         aln=lambda wc: star_bam_path(wc.sample, wc.unit),
         reads_per_gene=lambda wc: star_counts_path(wc.sample, wc.unit),

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -35,7 +35,7 @@ def get_fastqc_fastq(wildcards):
 
     return fastq
 
-def get_multiqc_inputs(wildcards):
+def get_multiqc_inputs(_wildcards=None):
     inputs = list(FASTQC_ZIP_OUTPUTS)
     for unit in units.itertuples():
         sample = unit.sample_name
@@ -67,7 +67,7 @@ def get_multiqc_inputs(wildcards):
 
 rule fastqc:
     input:
-        fastq=get_fastqc_fastq,
+        fastq=lambda wildcards: get_fastqc_fastq(wildcards),
     output:
         html=lambda wc: fastqc_output_path(wc.sample, wc.unit, wc.read, "html"),
         zip=lambda wc: fastqc_output_path(wc.sample, wc.unit, wc.read, "zip"),
@@ -280,7 +280,7 @@ rule rseqc_readgc:
 
 rule multiqc:
     input:
-        get_multiqc_inputs,
+        lambda wildcards: get_multiqc_inputs(wildcards),
     threads: 32
     output:
         html=cohort_path("reports", "multiqc", "multiqc_report.html"),

--- a/workflow/rules/trim.smk
+++ b/workflow/rules/trim.smk
@@ -13,7 +13,7 @@ rule get_sra:
 
 rule cutadapt_pipe:
     input:
-        get_cutadapt_pipe_input,
+        lambda wildcards: get_cutadapt_pipe_input(wildcards),
     output:
         pipe("pipe/cutadapt/{sample}/{unit}.{fq}.{ext}"),
     log:
@@ -29,7 +29,7 @@ rule cutadapt_pipe:
 
 rule cutadapt_pe:
     input:
-        get_cutadapt_input,
+        lambda wildcards: get_cutadapt_input(wildcards),
     output:
         fastq1=trimmed_fastq_path("{sample}", "{unit}", "fq1"),
         fastq2=trimmed_fastq_path("{sample}", "{unit}", "fq2"),
@@ -48,7 +48,7 @@ rule cutadapt_pe:
 
 rule cutadapt_se:
     input:
-        get_cutadapt_input,
+        lambda wildcards: get_cutadapt_input(wildcards),
     output:
         fastq=trimmed_fastq_path("{sample}", "{unit}", "single"),
         qc=trimmed_qc_path("{sample}", "{unit}", "single.qc.txt"),


### PR DESCRIPTION
## Summary
- update Snakemake rules to wrap dynamic inputs in lambdas for compatibility with newer Snakemake versions
- add helper functions for align and MultiQC rules so inputs resolve to concrete file paths

## Testing
- not run (Snakemake not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d65abebef4833187641d33a4547f65