### PR TITLE
Fix align rule output specification

### DIFF
--- a/workflow/rules/align.smk
+++ b/workflow/rules/align.smk
@@ -11,8 +11,8 @@ rule align:
     input:
         lambda wildcards: get_align_inputs(wildcards),
     output:
-        aln=lambda wc: star_bam_path(wc.sample, wc.unit),
-        reads_per_gene=lambda wc: star_counts_path(wc.sample, wc.unit),
+        aln=star_bam_path("{sample}", "{unit}"),
+        reads_per_gene=star_counts_path("{sample}", "{unit}"),
     log:
         "logs/star/{sample}_{unit}.log",
     benchmark:


### PR DESCRIPTION
## Summary
- define the align rule outputs with wildcard-formatted paths instead of lambda functions to satisfy Snakemake's restrictions on functional outputs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d665d372a08331a55867d68308744b