### PR TITLE
Fix align input specification for Snakemake

### DIFF
--- a/workflow/rules/align.smk
+++ b/workflow/rules/align.smk
@@ -1,15 +1,9 @@
-def get_align_inputs(wildcards):
-    files = dict(get_fq(wildcards))
-    files.update({
-        "index": "resources/star_genome",
-        "gtf": "resources/genome.gtf",
-    })
-    return files
-
-
 rule align:
     input:
-        lambda wildcards: get_align_inputs(wildcards),
+        fq1=lambda wildcards: get_fq(wildcards)["fq1"],
+        fq2=lambda wildcards: get_fq(wildcards).get("fq2", []),
+        index="resources/star_genome",
+        gtf="resources/genome.gtf",
     output:
         aln=star_bam_path("{sample}", "{unit}"),
         reads_per_gene=star_counts_path("{sample}", "{unit}"),


### PR DESCRIPTION
## Summary
- provide explicit align rule inputs for fq1, fq2, genome index, and gtf so Snakemake receives strings instead of a list-wrapped dictionary

## Testing
- snakemake --snakefile workflow/Snakefile --cores 1 --dry-run *(fails: snakemake command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d66780bd088331bd0df4d53825911a